### PR TITLE
Add auth and user API services

### DIFF
--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,44 @@
+import { ApiResponse, PostRegisterRequest, PostRegisterResponse } from '../types';
+import { BASE_API_URL } from '../config/config';
+
+class AuthService {
+  private async post<T>(endpoint: string, body: any): Promise<ApiResponse<T>> {
+    try {
+      const response = await fetch(`${BASE_API_URL}${endpoint}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: data.error || `HTTP error! status: ${response.status}`,
+        };
+      }
+
+      return {
+        success: true,
+        data,
+      };
+    } catch (error) {
+      console.error('AuthService POST request failed:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Network error',
+      };
+    }
+  }
+
+  async register(payload: PostRegisterRequest): Promise<ApiResponse<PostRegisterResponse>> {
+    return this.post<PostRegisterResponse>('auth/register', payload);
+  }
+}
+
+export const authService = new AuthService();
+export default authService;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,61 @@
+import { ApiResponse, GetUserInfoResponse, UpdateUserProfileRequest, UpdateUserProfileResponse } from '../types';
+import { BASE_API_URL } from '../config/config';
+
+class UserService {
+  private async get<T>(endpoint: string): Promise<ApiResponse<T>> {
+    try {
+      const response = await fetch(`${BASE_API_URL}${endpoint}`, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        return { success: false, error: data.error || `HTTP error! status: ${response.status}` };
+      }
+
+      return { success: true, data };
+    } catch (error) {
+      console.error('UserService GET request failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Network error' };
+    }
+  }
+
+  private async put<T>(endpoint: string, body: any): Promise<ApiResponse<T>> {
+    try {
+      const response = await fetch(`${BASE_API_URL}${endpoint}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        return { success: false, error: data.error || `HTTP error! status: ${response.status}` };
+      }
+
+      return { success: true, data };
+    } catch (error) {
+      console.error('UserService PUT request failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Network error' };
+    }
+  }
+
+  async getUserInfo(id: string): Promise<ApiResponse<GetUserInfoResponse>> {
+    return this.get<GetUserInfoResponse>(`User/${id}/info`);
+  }
+
+  async updateUserProfile(id: string, payload: UpdateUserProfileRequest): Promise<ApiResponse<UpdateUserProfileResponse>> {
+    return this.put<UpdateUserProfileResponse>(`User/${id}/profile`, payload);
+  }
+}
+
+export const userService = new UserService();
+export default userService;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,3 +38,40 @@ export interface IconProps {
   size?: number;
   className?: string;
 }
+
+export interface BaseResponse {
+  statusCode?: number;
+  description?: string | null;
+  userFriendly?: string | null;
+  moreInformation?: string | null;
+}
+
+export interface PostRegisterRequest {
+  userEmail: string;
+  password: string;
+  displayName?: string | null;
+}
+
+export interface PostRegisterResponse extends BaseResponse {}
+
+export interface GetUserInfoResponse extends BaseResponse {
+  id?: string | null;
+  userName?: string | null;
+  email?: string | null;
+  fullName?: string | null;
+  phoneNumber?: string | null;
+  role?: string | null;
+}
+
+export interface UpdateUserProfileRequest {
+  userId?: string | null;
+  displayName?: string | null;
+  email?: string | null;
+  age?: number | null;
+  bio?: string | null;
+  favoriteGenres?: string | null;
+  profilePictureUrl?: string | null;
+}
+
+export interface UpdateUserProfileResponse extends BaseResponse {}
+


### PR DESCRIPTION
## Summary
- introduce `authService` with register endpoint
- add `userService` to fetch and update user profiles
- extend shared types with models matching the API specification

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e75e680148325924f96e0ab6cca9e